### PR TITLE
Implement serial-based model selection

### DIFF
--- a/ProtocolVisionIV4/model_selector.py
+++ b/ProtocolVisionIV4/model_selector.py
@@ -1,8 +1,31 @@
 """Select and register models based on serial codes."""
 
-class ModelSelector:
-    """Placeholder for model selection logic."""
+from __future__ import annotations
 
-    def select_model(self, serial_code):
+from typing import Dict
+
+
+MODEL_MAP: Dict[str, str] = {
+    "A": "model_a.onnx",
+    "B": "model_b.onnx",
+}
+
+DEFAULT_MODEL = "default_model.onnx"
+
+class ModelSelector:
+    """Select a model based on the provided serial code."""
+
+    def select_model(self, serial_code: str) -> str:
         """Return the model for a given serial code."""
-        return None
+        return select_model_by_serial(serial_code)
+
+
+def select_model_by_serial(serial: str) -> str:
+    """Return the model name mapped from a serial number."""
+    if not serial:
+        return DEFAULT_MODEL
+    prefix = serial[0].upper()
+    return MODEL_MAP.get(prefix, DEFAULT_MODEL)
+
+
+__all__ = ["ModelSelector", "select_model_by_serial"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The folder structure outlined in the Thai documentation shows the key modules of
 `ProtocolVisionIV4/`【F:เอกสารโครงการ.md†L120-L131】:
 - `main.py` – entry point and user interface.
 - `camera_manager.py` – manage multiple camera connections.
-- `model_selector.py` – select and register models based on serial codes.
+- `model_selector.py` – auto-selects the correct model from a serial number.
 - `ai_processor.py` – optional AI/ML processing for images.
 - `serial_input.py` – handle serial codes from a scanner or manual input.
 - `logger.py` – handle logging and export (CSV/JSON).


### PR DESCRIPTION
## Summary
- map common serial prefixes to model names
- return default model for unknown serials
- expose new `select_model_by_serial` utility
- document auto-selection in the README

## Testing
- `python -m py_compile ProtocolVisionIV4/*.py`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852e451f6c88320ac118b2be953fd26