### PR TITLE
Add serial scanner input

### DIFF
--- a/ProtocolVisionIV4/config/config.json
+++ b/ProtocolVisionIV4/config/config.json
@@ -4,6 +4,8 @@
   "image_output_path": "outputs/images",
   "ai_model_path": "models/model.onnx",
   "log_path": "outputs/logs/app.log",
+  "scanner_port": "COM3",
+  "scanner_baud": 9600,
   "cameras": [
     {
       "name": "Cam1",

--- a/ProtocolVisionIV4/config_manager.py
+++ b/ProtocolVisionIV4/config_manager.py
@@ -24,6 +24,8 @@ class ConfigManager:
         "image_output_path": str,
         "ai_model_path": str,
         "log_path": str,
+        "scanner_port": str,
+        "scanner_baud": int,
         "cameras": list,
     }
 
@@ -63,6 +65,9 @@ class ConfigManager:
                 raise ConfigError(
                     f"Field '{field}' must be of type {field_type.__name__}"
                 )
+
+        if self.data.get("scanner_baud", 0) <= 0:
+            raise ConfigError("'scanner_baud' must be a positive integer")
 
         cameras = self.data.get("cameras", [])
         if not isinstance(cameras, list):

--- a/ProtocolVisionIV4/serial_input.py
+++ b/ProtocolVisionIV4/serial_input.py
@@ -1,8 +1,39 @@
 """Handle serial input from scanners or manual entry."""
 
-class SerialInput:
-    """Placeholder for serial input handling."""
+from __future__ import annotations
 
-    def read_code(self):
-        """Read a serial code from the scanner."""
-        return ""
+import serial
+from serial import SerialException
+
+
+class SerialInput:
+    """Read serial codes from a COM/USB scanner with manual fallback."""
+
+    def __init__(self, port: str, baudrate: int = 9600, timeout: float = 1.0) -> None:
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        try:
+            self.ser = serial.Serial(port, baudrate, timeout=timeout)
+        except SerialException:
+            self.ser = None
+
+    def read_code(self) -> str:
+        """Return a scanned code, or prompt for manual input if unavailable."""
+        if self.ser and self.ser.is_open:
+            try:
+                line = self.ser.readline().decode("utf-8").strip()
+                if line:
+                    return line
+            except SerialException:
+                pass
+        # manual fallback
+        return input("Enter code manually: ").strip()
+
+    def close(self) -> None:
+        """Close the serial connection if open."""
+        if self.ser and self.ser.is_open:
+            self.ser.close()
+
+
+__all__ = ["SerialInput"]

--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ The folder structure outlined in the Thai documentation shows the key modules of
 ## Setup and Usage
 1. Install Python 3.9 or newer.
 2. Clone this repository.
-3. Run `python ProtocolVisionIV4/main.py` to launch the application.
-4. Captured images and logs will be saved in the `outputs/` directory.
+3. Install dependencies with `pip install -r requirements.txt`.
+4. Run `python ProtocolVisionIV4/main.py` to launch the application.
+5. Captured images and logs will be saved in the `outputs/` directory.
 
 ## Camera Manager Overview
 
@@ -34,4 +35,10 @@ The `CameraManager` automatically connects to the correct camera type based on
 * **USB** – uses OpenCV to access a webcam.
 * **IV2/IV3/IV4** – connects over a mock TCP socket and sends `TRIGGER`/`IMAGE_OK` commands.
 * **VS** – simulates an SDK interface and returns a mocked image string.
+
+## Serial Input
+
+`SerialInput` reads a barcode scanner via a COM/USB port and falls back to
+manual entry when no data is received. The Thai documentation notes that serial
+codes can come from a scanner or be typed by the user【F:เอกสารโครงการ.md†L32-L40】.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+pyserial


### PR DESCRIPTION
## Summary
- include `pyserial` dependency
- configure scanner COM port and baud rate
- validate new scanner fields in `ConfigManager`
- implement `SerialInput` with manual fallback
- document scanner usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852f0711b8483208befe459dda4ebcd