### PR TITLE
Add model registry database

### DIFF
--- a/ProtocolVisionIV4/main.py
+++ b/ProtocolVisionIV4/main.py
@@ -19,7 +19,7 @@ from tkinter import messagebox, simpledialog
 from ProtocolVisionIV4.camera_manager import CameraManager, CameraError
 from ProtocolVisionIV4.config_manager import ConfigManager
 from ProtocolVisionIV4.image_saver import save_captured_image
-from ProtocolVisionIV4.model_selector import select_model_by_serial
+from ProtocolVisionIV4.model_selector import ModelSelector
 
 
 CONFIG_PATH = Path(__file__).resolve().parent / "config" / "config.json"
@@ -104,7 +104,9 @@ class App:
             "Serial", "Enter serial number:", parent=self.root
         )
         if serial:
-            model = select_model_by_serial(serial)
+            selector = ModelSelector()
+            model = selector.select_model(serial)
+            selector.register_model(serial, model)
             self.config.data["serial_number"] = serial
             self.config.data["model_name"] = model
             self.serial_var.set(serial)

--- a/ProtocolVisionIV4/model_selector.py
+++ b/ProtocolVisionIV4/model_selector.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from typing import Dict
+import sqlite3
+from datetime import datetime
+from pathlib import Path
 
 
 MODEL_MAP: Dict[str, str] = {
@@ -12,12 +15,32 @@ MODEL_MAP: Dict[str, str] = {
 
 DEFAULT_MODEL = "default_model"
 
+DB_PATH = Path(__file__).resolve().parent / "outputs" / "model_registry.db"
+
 class ModelSelector:
     """Select a model based on the provided serial code."""
 
     def select_model(self, serial_code: str) -> str:
         """Return the model for a given serial code."""
         return select_model_by_serial(serial_code)
+
+    def register_model(self, serial_code: str, model: str) -> None:
+        """Store the selected model along with a timestamp."""
+        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().isoformat(timespec="seconds")
+        with sqlite3.connect(DB_PATH) as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS selections ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT,"
+                " serial TEXT,"
+                " model TEXT,"
+                " timestamp TEXT"
+                ")"
+            )
+            conn.execute(
+                "INSERT INTO selections (serial, model, timestamp) VALUES (?, ?, ?)",
+                (serial_code, model, ts),
+            )
 
 
 def select_model_by_serial(serial: str) -> str:

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from ProtocolVisionIV4.camera_manager import CameraManager
 from ProtocolVisionIV4.config_manager import ConfigManager
 from ProtocolVisionIV4.image_saver import save_captured_image
-from ProtocolVisionIV4.model_selector import select_model_by_serial
+from ProtocolVisionIV4.model_selector import ModelSelector
 
 CONFIG_PATH = Path(__file__).resolve().parent / "ProtocolVisionIV4" / "config" / "config.json"
 
@@ -35,9 +35,11 @@ def main() -> None:
 
     serial = config.get("serial_number")
     logging.info("Selecting model for serial %s", serial)
-    model = select_model_by_serial(serial)
+    selector = ModelSelector()
+    model = selector.select_model(serial)
     config.data["model_name"] = model
     logging.info("Selected model: %s", model)
+    selector.register_model(serial, model)
 
     for name in camera_mgr.names():
         logging.info("Connecting camera %s", name)


### PR DESCRIPTION
## Summary
- log model selections into an SQLite database
- expose `ModelSelector.register_model`
- record selections in both CLI and GUI flows

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852f214a8288320992d4573d1e808af