### PR TITLE
Add OK/NG status in save_captured_image

### DIFF
--- a/ProtocolVisionIV4/image_saver.py
+++ b/ProtocolVisionIV4/image_saver.py
@@ -27,6 +27,7 @@ def save_captured_image(
     *,
     serial: str | None = None,
     camera_type: str | None = None,
+    ok: bool = True,
 ) -> str:
     """Save a captured image or placeholder file.
 
@@ -45,6 +46,8 @@ def save_captured_image(
         Override the serial number used in the file name.
     camera_type:
         Override the camera type used when saving.
+    ok:
+        ``True`` if the result was OK, ``False`` for NG.
 
     Returns
     -------
@@ -55,7 +58,8 @@ def save_captured_image(
     timestamp = datetime.now().strftime("%Y%m%d_%H%M")
     serial = serial or _SERIAL
     camera_type = camera_type or _CAMERA_TYPE
-    base_name = f"{serial}_{timestamp}"
+    status = "OK" if ok else "NG"
+    base_name = f"{serial}_{status}_{timestamp}"
     out_dir = Path(output_path)
     out_dir.mkdir(parents=True, exist_ok=True)
 

--- a/ProtocolVisionIV4/main.py
+++ b/ProtocolVisionIV4/main.py
@@ -87,11 +87,13 @@ class App:
         """Capture an image using the specified camera."""
         try:
             img = self.camera_mgr.capture_image(name)
+            ok = img is not None
             path = save_captured_image(
                 img,
                 self.config.get("image_output_path"),
                 serial=self.config.get("serial_number"),
                 camera_type=self.camera_mgr.cameras[name].camera_type,
+                ok=ok,
             )
             self.image_var.set(path)
             messagebox.showinfo("Capture", f"{name} image saved to {path}")

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ The folder structure outlined in the Thai documentation shows the key modules of
 - `ai_processor.py` – optional AI/ML processing for images.
 - `serial_input.py` – handle serial codes from a scanner or manual input.
 - `logger.py` – handle logging and export (CSV/JSON).
-- `image_saver.py` – save captured images or placeholder logs with timestamped
-  filenames.
+- `image_saver.py` – save captured images with status-based filenames like
+  `SERIAL_OK_YYYYMMDD_HHMM.jpg` (or `SERIAL_NG_...`) and placeholder logs for
+  mock cameras.
 - `config/config.json` – runtime configuration loaded by `ConfigManager`. It now
   contains a `cameras` array so multiple cameras can be configured.
 - The configuration's `model_name` is automatically updated from the serial number.

--- a/main.py
+++ b/main.py
@@ -46,6 +46,7 @@ def main() -> None:
         camera_mgr.connect(name)
         logging.info("Capturing image from %s", name)
         image = camera_mgr.capture_image(name)
+        ok = image is not None
 
         logging.info("Saving image")
         image_path = save_captured_image(
@@ -53,6 +54,7 @@ def main() -> None:
             config.get("image_output_path"),
             serial=serial,
             camera_type=camera_mgr.cameras[name].camera_type,
+            ok=ok,
         )
         logging.info("Image from %s saved to %s", name, image_path)
         camera_mgr.release(name)


### PR DESCRIPTION
## Summary
- allow passing an OK flag when saving a capture
- save filenames as `<serial>_OK_<timestamp>` or `<serial>_NG_<timestamp>`
- update CLI and Tkinter UI to pass the status
- document the new filename format in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852f39c699c83209224bb38487415ff