### PR TITLE
Add advanced logging with webhook & MQTT

### DIFF
--- a/ProtocolVisionIV4/config/config.json
+++ b/ProtocolVisionIV4/config/config.json
@@ -7,6 +7,10 @@
   "log_path": "outputs/logs/app.log",
   "scanner_port": "COM3",
   "scanner_baud": 9600,
+  "webhook_url": "",
+  "mqtt_broker": "localhost",
+  "mqtt_port": 1883,
+  "mqtt_topic": "protocol/vision",
   "cameras": [
     {
       "name": "Cam1",

--- a/ProtocolVisionIV4/config_manager.py
+++ b/ProtocolVisionIV4/config_manager.py
@@ -27,6 +27,10 @@ class ConfigManager:
         "log_path": str,
         "scanner_port": str,
         "scanner_baud": int,
+        "webhook_url": str,
+        "mqtt_broker": str,
+        "mqtt_port": int,
+        "mqtt_topic": str,
         "cameras": list,
     }
 
@@ -69,6 +73,8 @@ class ConfigManager:
 
         if self.data.get("scanner_baud", 0) <= 0:
             raise ConfigError("'scanner_baud' must be a positive integer")
+        if self.data.get("mqtt_port", 0) <= 0:
+            raise ConfigError("'mqtt_port' must be a positive integer")
 
         cameras = self.data.get("cameras", [])
         if not isinstance(cameras, list):

--- a/ProtocolVisionIV4/logger.py
+++ b/ProtocolVisionIV4/logger.py
@@ -1,8 +1,95 @@
-"""Logging and export utilities."""
+"""Advanced logging utilities with CSV/JSON export and integrations."""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict
+
+import requests
+import paho.mqtt.publish as mqtt_publish
+
 
 class Logger:
-    """Placeholder for logging implementation."""
+    """Log messages to console, files, and optional integrations."""
 
-    def log(self, message: str) -> None:
-        """Log a message."""
-        print(message)
+    def __init__(
+        self,
+        log_path: str,
+        webhook_url: str = "",
+        mqtt_broker: str = "",
+        mqtt_port: int = 1883,
+        mqtt_topic: str = "",
+    ) -> None:
+        self.log_dir = Path(log_path).parent
+        self.log_dir.mkdir(parents=True, exist_ok=True)
+        self.webhook_url = webhook_url
+        self.mqtt_broker = mqtt_broker
+        self.mqtt_port = mqtt_port
+        self.mqtt_topic = mqtt_topic
+
+        self.logger = logging.getLogger("ProtocolVision")
+        if not self.logger.handlers:
+            fmt = "%(asctime)s - %(levelname)s - %(message)s"
+            self.logger.setLevel(logging.INFO)
+            stream_handler = logging.StreamHandler()
+            stream_handler.setFormatter(logging.Formatter(fmt))
+            file_handler = logging.FileHandler(log_path)
+            file_handler.setFormatter(logging.Formatter(fmt))
+            self.logger.addHandler(stream_handler)
+            self.logger.addHandler(file_handler)
+
+        self.csv_path = self.log_dir / "log.csv"
+        self.json_path = self.log_dir / "log.jsonl"
+        if not self.csv_path.exists():
+            with self.csv_path.open("w", newline="", encoding="utf-8") as f:
+                writer = csv.DictWriter(
+                    f, fieldnames=["timestamp", "level", "message"]
+                )
+                writer.writeheader()
+
+    def _write_csv(self, data: Dict[str, Any]) -> None:
+        with self.csv_path.open("a", newline="", encoding="utf-8") as f:
+            writer = csv.DictWriter(f, fieldnames=["timestamp", "level", "message"])
+            writer.writerow(data)
+
+    def _write_json(self, data: Dict[str, Any]) -> None:
+        with self.json_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(data, ensure_ascii=False) + "\n")
+
+    def log(self, level: str, message: str) -> None:
+        """Log a message at the specified level."""
+        ts = datetime.now().isoformat(timespec="seconds")
+        log_data = {"timestamp": ts, "level": level.upper(), "message": message}
+        getattr(self.logger, level.lower())(message)
+        self._write_csv(log_data)
+        self._write_json(log_data)
+
+    def send_webhook(self, payload: Dict[str, Any]) -> None:
+        """Send payload via HTTP POST if a webhook URL is configured."""
+        if not self.webhook_url:
+            return
+        try:
+            requests.post(self.webhook_url, json=payload, timeout=5)
+        except Exception as exc:  # pragma: no cover - network issues
+            self.logger.error("Webhook POST failed: %s", exc)
+
+    def publish_mqtt(self, payload: Dict[str, Any]) -> None:
+        """Publish payload to the configured MQTT topic."""
+        if not (self.mqtt_broker and self.mqtt_topic):
+            return
+        try:
+            mqtt_publish.single(
+                self.mqtt_topic,
+                json.dumps(payload),
+                hostname=self.mqtt_broker,
+                port=self.mqtt_port,
+            )
+        except Exception as exc:  # pragma: no cover - network issues
+            self.logger.error("MQTT publish failed: %s", exc)
+
+
+__all__ = ["Logger"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ The folder structure outlined in the Thai documentation shows the key modules of
   contains a `cameras` array so multiple cameras can be configured.
 - The configuration's `model_name` is automatically updated from the serial number.
 - Set `use_ai` to `true` in `config.json` to enable YOLOv5 inspection with
-  `ai_processor.process_image`.
+`ai_processor.process_image`.
+
+## Logging and Integration
+
+The documentation describes a **Log & Exporter** stage that outputs CSV/JSON and forwards results via webhook or MQTT【F:เอกสารโครงการ.md†L91-L112】. The `Logger` module writes log entries to both `log.csv` and `log.jsonl` under `outputs/logs/` and exposes `send_webhook` and `publish_mqtt` helpers. Configure `webhook_url`, `mqtt_broker`, `mqtt_port`, and `mqtt_topic` in `config/config.json` to enable these integrations.
 
 ## Setup and Usage
 1. Install Python 3.9 or newer.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 pyserial
 ultralytics
+requests
+paho-mqtt


### PR DESCRIPTION
## Summary
- implement CSV/JSON logger with webhook & MQTT helpers
- expose webhook/mqtt options in configuration
- use new logger from CLI `main.py`
- document logging/integration setup
- add requests and paho-mqtt to requirements

## Testing
- `python -m py_compile ProtocolVisionIV4/logger.py ProtocolVisionIV4/config_manager.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_6852f5b46f9c8320b2465544d3161d11