### PR TITLE
Allow config overrides

### DIFF
--- a/ProtocolVisionIV4/config/config.json
+++ b/ProtocolVisionIV4/config/config.json
@@ -5,6 +5,7 @@
   "ai_model_path": "models/model.onnx",
   "use_ai": false,
   "log_path": "outputs/logs/app.log",
+  "model_registry_path": "outputs/model_registry.db",
   "scanner_port": "COM3",
   "scanner_baud": 9600,
   "webhook_url": "",

--- a/ProtocolVisionIV4/config_manager.py
+++ b/ProtocolVisionIV4/config_manager.py
@@ -25,6 +25,7 @@ class ConfigManager:
         "ai_model_path": str,
         "use_ai": bool,
         "log_path": str,
+        "model_registry_path": str,
         "scanner_port": str,
         "scanner_baud": int,
         "webhook_url": str,

--- a/ProtocolVisionIV4/image_saver.py
+++ b/ProtocolVisionIV4/image_saver.py
@@ -11,12 +11,15 @@ try:
 except Exception:  # pragma: no cover - optional dependency
     cv2 = None
 
+import os
+
 from .config_manager import ConfigManager
 from .ai_processor import AIProcessor
 
 # Load configuration once for default serial number and camera type. These
 # values can be overridden when calling :func:`save_captured_image`.
-_CONFIG_PATH = Path(__file__).resolve().parent / "config" / "config.json"
+_DEFAULT_CONFIG = Path(__file__).resolve().parent / "config" / "config.json"
+_CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", _DEFAULT_CONFIG))
 _config = ConfigManager(_CONFIG_PATH)
 _SERIAL = _config.get("serial_number", "UNKNOWN")
 _CAMERA_TYPE = "USB"

--- a/ProtocolVisionIV4/main.py
+++ b/ProtocolVisionIV4/main.py
@@ -9,6 +9,9 @@ if __package__ in {None, ""}:
 
     sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+import argparse
+import os
+
 import json
 from pathlib import Path
 from typing import Any
@@ -22,7 +25,8 @@ from ProtocolVisionIV4.image_saver import save_captured_image
 from ProtocolVisionIV4.model_selector import ModelSelector
 
 
-CONFIG_PATH = Path(__file__).resolve().parent / "config" / "config.json"
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "config" / "config.json"
+CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", DEFAULT_CONFIG))
 
 
 class App:
@@ -130,6 +134,15 @@ class App:
 
 def main() -> None:
     """Entry point for launching the Tkinter application."""
+    global CONFIG_PATH
+    parser = argparse.ArgumentParser(description="Protocol Vision IV4 UI")
+    parser.add_argument(
+        "--config", default=str(CONFIG_PATH), help="Path to configuration file"
+    )
+    args = parser.parse_args()
+    CONFIG_PATH = Path(args.config)
+    os.environ["CONFIG_PATH"] = str(CONFIG_PATH)
+
     root = tk.Tk()
     App(root)
     root.mainloop()

--- a/ProtocolVisionIV4/model_selector.py
+++ b/ProtocolVisionIV4/model_selector.py
@@ -6,6 +6,9 @@ from typing import Dict
 import sqlite3
 from datetime import datetime
 from pathlib import Path
+import os
+
+from .config_manager import ConfigManager
 
 
 MODEL_MAP: Dict[str, str] = {
@@ -15,7 +18,15 @@ MODEL_MAP: Dict[str, str] = {
 
 DEFAULT_MODEL = "default_model"
 
-DB_PATH = Path(__file__).resolve().parent / "outputs" / "model_registry.db"
+_DEFAULT_CONFIG = Path(__file__).resolve().parent / "config" / "config.json"
+_CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", _DEFAULT_CONFIG))
+_CONFIG = ConfigManager(_CONFIG_PATH)
+DB_PATH = Path(
+    _CONFIG.get(
+        "model_registry_path",
+        Path(__file__).resolve().parent / "outputs" / "model_registry.db",
+    )
+)
 
 class ModelSelector:
     """Select a model based on the provided serial code."""

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The folder structure outlined in the Thai documentation shows the key modules of
   mock cameras.
 - `config/config.json` – runtime configuration loaded by `ConfigManager`. It now
   contains a `cameras` array so multiple cameras can be configured.
+- The file also defines `model_registry_path`, which stores the selection history.
 - The configuration's `model_name` is automatically updated from the serial number.
 - Set `use_ai` to `true` in `config.json` to enable YOLOv5 inspection with
 `ai_processor.process_image`.
@@ -43,6 +44,8 @@ Each capture result is logged and then sent via `send_to_workflow`, which posts 
 3. Install dependencies with `pip install -r requirements.txt`.
 4. Run `python ProtocolVisionIV4/main.py` to launch the application.
 5. Captured images and logs will be saved in the `outputs/` directory.
+6. Set the `CONFIG_PATH` environment variable or pass `--config <file>` to
+   override the configuration file location.
 
 ## Camera Manager Overview
 

--- a/main.py
+++ b/main.py
@@ -1,24 +1,34 @@
 import argparse
 import logging
+import os
 from pathlib import Path
 
-from ProtocolVisionIV4.camera_manager import CameraManager
-from ProtocolVisionIV4.config_manager import ConfigManager
-from ProtocolVisionIV4.image_saver import save_captured_image
-from ProtocolVisionIV4.model_selector import ModelSelector
-from ProtocolVisionIV4.logger import Logger
-from ProtocolVisionIV4.workflow import send_to_workflow
 
-CONFIG_PATH = Path(__file__).resolve().parent / "ProtocolVisionIV4" / "config" / "config.json"
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "ProtocolVisionIV4" / "config" / "config.json"
+CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", DEFAULT_CONFIG))
 
 
 def main() -> None:
     """Run a simple CLI capture workflow."""
+    global CONFIG_PATH
     parser = argparse.ArgumentParser(description="Protocol Vision IV4 CLI")
     parser.add_argument(
         "--debug", action="store_true", help="Enable verbose logging"
     )
+    parser.add_argument(
+        "--config", default=str(CONFIG_PATH), help="Path to configuration file"
+    )
     args = parser.parse_args()
+
+    CONFIG_PATH = Path(args.config)
+    os.environ["CONFIG_PATH"] = str(CONFIG_PATH)
+
+    from ProtocolVisionIV4.camera_manager import CameraManager
+    from ProtocolVisionIV4.config_manager import ConfigManager
+    from ProtocolVisionIV4.image_saver import save_captured_image
+    from ProtocolVisionIV4.model_selector import ModelSelector
+    from ProtocolVisionIV4.logger import Logger
+    from ProtocolVisionIV4.workflow import send_to_workflow
 
     log_level = logging.DEBUG if args.debug else logging.INFO
     logging.basicConfig(level=log_level, format="%(asctime)s - %(levelname)s - %(message)s")


### PR DESCRIPTION
## Summary
- support `CONFIG_PATH` via env var or `--config` option
- load `model_registry_path` from configuration
- remove hard-coded paths from modules
- document configuration overrides

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852f7cf0b4c8320adc0a89a406ca01c