### PR TITLE
Refactor model selector helpers

### DIFF
--- a/ProtocolVisionIV4/config_manager.py
+++ b/ProtocolVisionIV4/config_manager.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
-from .model_selector import select_model_by_serial
+from .utils import select_model_by_serial
 
 
 class ConfigError(Exception):

--- a/ProtocolVisionIV4/model_selector.py
+++ b/ProtocolVisionIV4/model_selector.py
@@ -2,34 +2,41 @@
 
 from __future__ import annotations
 
-from typing import Dict
+import os
 import sqlite3
 from datetime import datetime
 from pathlib import Path
-import os
+from typing import Any
 
-from .config_manager import ConfigManager
-
-
-MODEL_MAP: Dict[str, str] = {
-    "IV4-001": "model_abc",
-    "VS-888": "model_xyz",
-}
-
-DEFAULT_MODEL = "default_model"
+from .utils import select_model_by_serial
 
 _DEFAULT_CONFIG = Path(__file__).resolve().parent / "config" / "config.json"
-_CONFIG_PATH = Path(os.environ.get("CONFIG_PATH", _DEFAULT_CONFIG))
-_CONFIG = ConfigManager(_CONFIG_PATH)
-DB_PATH = Path(
-    _CONFIG.get(
-        "model_registry_path",
-        Path(__file__).resolve().parent / "outputs" / "model_registry.db",
-    )
-)
+
 
 class ModelSelector:
-    """Select a model based on the provided serial code."""
+    """Select and register models based on serial codes."""
+
+    def __init__(self, config_path: str | Path | None = None) -> None:
+        self.config_path = Path(config_path or os.environ.get("CONFIG_PATH", _DEFAULT_CONFIG))
+        self._config: Any | None = None
+        self._db_path: Path | None = None
+
+    def _load_config(self) -> Any:
+        if self._config is None:
+            from .config_manager import ConfigManager
+            self._config = ConfigManager(self.config_path)
+        return self._config
+
+    def _get_db_path(self) -> Path:
+        if self._db_path is None:
+            config = self._load_config()
+            self._db_path = Path(
+                config.get(
+                    "model_registry_path",
+                    Path(__file__).resolve().parent / "outputs" / "model_registry.db",
+                )
+            )
+        return self._db_path
 
     def select_model(self, serial_code: str) -> str:
         """Return the model for a given serial code."""
@@ -37,9 +44,10 @@ class ModelSelector:
 
     def register_model(self, serial_code: str, model: str) -> None:
         """Store the selected model along with a timestamp."""
-        DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+        db_path = self._get_db_path()
+        db_path.parent.mkdir(parents=True, exist_ok=True)
         ts = datetime.now().isoformat(timespec="seconds")
-        with sqlite3.connect(DB_PATH) as conn:
+        with sqlite3.connect(db_path) as conn:
             conn.execute(
                 "CREATE TABLE IF NOT EXISTS selections ("
                 "id INTEGER PRIMARY KEY AUTOINCREMENT,"
@@ -54,11 +62,4 @@ class ModelSelector:
             )
 
 
-def select_model_by_serial(serial: str) -> str:
-    """Return the model name mapped from a serial number."""
-    if not serial:
-        return DEFAULT_MODEL
-    return MODEL_MAP.get(serial, DEFAULT_MODEL)
-
-
-__all__ = ["ModelSelector", "select_model_by_serial"]
+__all__ = ["ModelSelector"]

--- a/ProtocolVisionIV4/utils.py
+++ b/ProtocolVisionIV4/utils.py
@@ -1,0 +1,22 @@
+"""General helper utilities for Protocol Vision IV4."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+MODEL_MAP: Dict[str, str] = {
+    "IV4-001": "model_abc",
+    "VS-888": "model_xyz",
+}
+
+DEFAULT_MODEL = "default_model"
+
+
+def select_model_by_serial(serial: str) -> str:
+    """Return the model name mapped from a serial number."""
+    if not serial:
+        return DEFAULT_MODEL
+    return MODEL_MAP.get(serial, DEFAULT_MODEL)
+
+
+__all__ = ["select_model_by_serial", "MODEL_MAP", "DEFAULT_MODEL"]


### PR DESCRIPTION
## Summary
- add `utils.py` with `select_model_by_serial`
- update config manager to use the helper
- simplify `ModelSelector` and lazily load `ConfigManager`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856bb62c5748320bf68af78726e37e3